### PR TITLE
Add step to install less required by `wp-cli`

### DIFF
--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -86,6 +86,9 @@ RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli
 	&& chmod +x wp-cli.phar \
 	&& mv wp-cli.phar /usr/local/bin/wp
 
+# Install less, required for wp-cli.
+RUN apt-get update && apt-get install -y less
+
 # XDebug
 RUN pecl install xdebug \
     && docker-php-ext-enable xdebug \

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -92,6 +92,9 @@ RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli
 	&& chmod +x wp-cli.phar \
 	&& mv wp-cli.phar /usr/local/bin/wp
 
+# Install less, required for wp-cli.
+RUN apt-get update && apt-get install -y less
+
 # XDebug
 RUN pecl install xdebug \
     && docker-php-ext-enable xdebug \

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -118,6 +118,9 @@ RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli
 	&& chmod +x wp-cli.phar \
 	&& mv wp-cli.phar /usr/local/bin/wp
 
+# Install less, required for wp-cli.
+RUN apt-get update && apt-get install -y less
+
 # XDebug
 RUN pecl install xdebug \
     && docker-php-ext-enable xdebug \


### PR DESCRIPTION
Currently running `wp` in the container gives the following error since `less` doesn't exist in the container image.
```sh
www-data@df1ad873a5ee:~/html$ wp
sh: 1: less: not found
```

This PR adds a `RUN` step in Dockerfile to add `less` in the container image.